### PR TITLE
v0.11.5: add proxy deposit abi and add it to contracts so log event is exposed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/contracts/proxy-deposit-abi.json
+++ b/src/contracts/proxy-deposit-abi.json
@@ -1,0 +1,135 @@
+{
+  "networks": {
+    "1": {
+      "links": {},
+      "address": "0xD54f502e184B6B739d7D27a6410a67dc462D69c8",
+    },
+    "3": {
+      "links": {},
+      "address": "0x014F738EAd8Ec6C50BCD456a971F8B84Cd693BBe",
+    }
+  },
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "starkwareContractAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "usdcAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "usdcAssetType",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "source",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "exchangeWrapper",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "tokenFrom",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokenFromAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokenToAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "LogConvertedDeposit",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "STARKWARE_CONTRACT",
+      "outputs": [
+        {
+          "internalType": "contract I_StarkwareContract",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenFrom",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenFromAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "exchangeWrapper",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "starkKey",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "positionId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "deposit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/src/lib/Contracts.ts
+++ b/src/lib/Contracts.ts
@@ -31,9 +31,9 @@ import {
 
 import factRegistryAbi from '../contracts/fact-registry-abi.json';
 import mintableTokenAbi from '../contracts/mintable-token-abi.json';
+import proxyDepositAbi from '../contracts/proxy-deposit-abi.json';
 import starkwarePerpetualAbi from '../contracts/starkware-perpetual-abi.json';
 import usdcAbi from '../contracts/usdc-abi.json';
-import proxyDepositAbi from '../contracts/proxy-deposit-abi.json';
 // Contracts
 import {
   TxResult,

--- a/src/lib/Contracts.ts
+++ b/src/lib/Contracts.ts
@@ -33,6 +33,7 @@ import factRegistryAbi from '../contracts/fact-registry-abi.json';
 import mintableTokenAbi from '../contracts/mintable-token-abi.json';
 import starkwarePerpetualAbi from '../contracts/starkware-perpetual-abi.json';
 import usdcAbi from '../contracts/usdc-abi.json';
+import proxyDepositAbi from '../contracts/proxy-deposit-abi.json';
 // Contracts
 import {
   TxResult,
@@ -71,6 +72,7 @@ export class Contracts {
   public starkwarePerpetual: Contract;
   public collateralToken: Contract;
   public mintableToken: Contract;
+  public proxyDepositContract: Contract;
 
   constructor(
     provider: Provider,
@@ -97,6 +99,7 @@ export class Contracts {
     this.starkwarePerpetual = this.addContract(starkwarePerpetualAbi);
     this.collateralToken = this.addContract(usdcAbi);
     this.mintableToken = this.addContract(mintableTokenAbi);
+    this.proxyDepositContract = this.addContract(proxyDepositAbi);
     this.setProvider(provider, networkId);
     this.setDefaultAccount(this.web3.eth.defaultAccount as string);
   }


### PR DESCRIPTION
the proxy addresses in the abi are palceholders. In the future, I think the proxy should be added to modules/exchange to expose the methods to call the contracts?