### PR TITLE
v0.12.6: add all biconomy options and register [BAC-2043]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/contracts/proxy-deposit-abi.json
+++ b/src/contracts/proxy-deposit-abi.json
@@ -2,11 +2,11 @@
   "networks": {
     "1": {
       "links": {},
-      "address": "0x029bB89d64695D6A461eEbC1Aab4a4C8657a3f22"
+      "address": "0x174FBe9Bf9B8838c4DfA875c29368A17e8877E6A"
     },
     "3": {
       "links": {},
-      "address": "0x029bB89d64695D6A461eEbC1Aab4a4C8657a3f22"
+      "address": "0x174FBe9Bf9B8838c4DfA875c29368A17e8877E6A"
     }
   },
   "abi": [
@@ -26,6 +26,11 @@
           "internalType": "uint256",
           "name": "usdcAssetType",
           "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_trustedForwarder",
+          "type": "address"
         }
       ],
       "stateMutability": "nonpayable",
@@ -134,6 +139,11 @@
           "internalType": "bytes",
           "name": "data",
           "type": "bytes"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
         }
       ],
       "name": "approveSwapAndDepositERC20",
@@ -163,6 +173,11 @@
           "internalType": "uint256",
           "name": "positionId",
           "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
         }
       ],
       "name": "deposit",
@@ -206,6 +221,11 @@
           "internalType": "bytes",
           "name": "data",
           "type": "bytes"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
         }
       ],
       "name": "depositERC20",
@@ -244,6 +264,11 @@
         {
           "internalType": "bytes",
           "name": "data",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
           "type": "bytes"
         }
       ],
@@ -300,7 +325,7 @@
           "type": "string"
         }
       ],
-      "stateMutability": "view",
+      "stateMutability": "pure",
       "type": "function"
     }
   ]

--- a/src/modules/Exchange.ts
+++ b/src/modules/Exchange.ts
@@ -128,10 +128,12 @@ export class Exchange {
       humanAmount,
       starkKey,
       positionId,
+      signature = Buffer.from('', 'utf8'),
     }: {
       humanAmount: string,
       starkKey: string,
       positionId: BigNumberable,
+      signature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -140,6 +142,7 @@ export class Exchange {
         humanCollateralAmountToUint256(humanAmount),
         starkKeyToUint256(starkKey),
         bignumberableToUint256(positionId),
+        signature,
       ).send(options);
     }
 
@@ -149,6 +152,7 @@ export class Exchange {
         humanCollateralAmountToUint256(humanAmount),
         starkKeyToUint256(starkKey),
         bignumberableToUint256(positionId),
+        signature,
       ),
       options,
     );
@@ -164,6 +168,13 @@ export class Exchange {
     },
     options?: SendOptions,
   ): Promise<TxResult> {
+    if (options?.sendGaslessTransaction) {
+      return this.contracts.proxyDepositContract.methods.approveSwap(
+        tokenFrom,
+        allowanceTarget,
+      ).send(options);
+    }
+
     return this.contracts.send(
       this.contracts.proxyDepositContract,
       this.contracts.proxyDepositContract.methods.approveSwap(
@@ -180,14 +191,29 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
+      signature = Buffer.from('', 'utf8'),
     }: {
       humanMinUsdcAmount: string,
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
+      signature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
+    if (options?.sendGaslessTransaction) {
+      return this.contracts.proxyDepositContract.methods.depositERC20(
+        zeroExResponseObject.sellTokenAddress,
+        zeroExResponseObject.sellAmount,
+        humanCollateralAmountToUint256(humanMinUsdcAmount),
+        starkKeyToUint256(starkKey),
+        bignumberableToUint256(positionId),
+        zeroExResponseObject.to,
+        zeroExResponseObject.data,
+        signature,
+      ).send(options);
+    }
+
     return this.contracts.send(
       this.contracts.proxyDepositContract,
       this.contracts.proxyDepositContract.methods.depositERC20(
@@ -198,6 +224,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
+        signature,
       ),
       options,
     );
@@ -209,14 +236,30 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
+      signature = Buffer.from('', 'utf8'),
     }: {
       humanMinUsdcAmount: string,
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
+      signature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
+    if (options?.sendGaslessTransaction) {
+      return this.contracts.proxyDepositContract.methods.approveSwapAndDepositERC20(
+        zeroExResponseObject.sellTokenAddress,
+        zeroExResponseObject.sellAmount,
+        humanCollateralAmountToUint256(humanMinUsdcAmount),
+        starkKeyToUint256(starkKey),
+        bignumberableToUint256(positionId),
+        zeroExResponseObject.to,
+        zeroExResponseObject.allowanceTarget,
+        zeroExResponseObject.data,
+        signature,
+      ).send(options);
+    }
+
     return this.contracts.send(
       this.contracts.proxyDepositContract,
       this.contracts.proxyDepositContract.methods.approveSwapAndDepositERC20(
@@ -228,6 +271,7 @@ export class Exchange {
         zeroExResponseObject.to,
         zeroExResponseObject.allowanceTarget,
         zeroExResponseObject.data,
+        signature,
       ),
       options,
     );
@@ -238,10 +282,12 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
+      signature = Buffer.from('', 'utf8'),
     }: {
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
+      signature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -249,6 +295,17 @@ export class Exchange {
       throw Error(
         `proxyDepositEth: A transaction value ${options.value} was provided which does not match the swap cost of ${zeroExResponseObject.value}`,
       );
+    }
+
+    if (options?.sendGaslessTransaction) {
+      return this.contracts.proxyDepositContract.methods.depositEth(
+        zeroExResponseObject.buyAmount,
+        starkKeyToUint256(starkKey),
+        bignumberableToUint256(positionId),
+        zeroExResponseObject.to,
+        zeroExResponseObject.data,
+        signature,
+      ).send({ ...options, value: zeroExResponseObject.value });
     }
 
     return this.contracts.send(
@@ -259,6 +316,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
+        signature,
       ),
       { ...options, value: zeroExResponseObject.value },
     );

--- a/src/modules/Exchange.ts
+++ b/src/modules/Exchange.ts
@@ -128,12 +128,12 @@ export class Exchange {
       humanAmount,
       starkKey,
       positionId,
-      signature = Buffer.from('', 'utf8'),
+      registerUserSignature = Buffer.from('', 'utf8'),
     }: {
       humanAmount: string,
       starkKey: string,
       positionId: BigNumberable,
-      signature?: Buffer,
+      registerUserSignature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -142,7 +142,7 @@ export class Exchange {
         humanCollateralAmountToUint256(humanAmount),
         starkKeyToUint256(starkKey),
         bignumberableToUint256(positionId),
-        signature,
+        registerUserSignature,
       ).send(options);
     }
 
@@ -152,7 +152,7 @@ export class Exchange {
         humanCollateralAmountToUint256(humanAmount),
         starkKeyToUint256(starkKey),
         bignumberableToUint256(positionId),
-        signature,
+        registerUserSignature,
       ),
       options,
     );
@@ -191,13 +191,13 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
-      signature = Buffer.from('', 'utf8'),
+      registerUserSignature = Buffer.from('', 'utf8'),
     }: {
       humanMinUsdcAmount: string,
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
-      signature?: Buffer,
+      registerUserSignature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -210,7 +210,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ).send(options);
     }
 
@@ -224,7 +224,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ),
       options,
     );
@@ -236,13 +236,13 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
-      signature = Buffer.from('', 'utf8'),
+      registerUserSignature = Buffer.from('', 'utf8'),
     }: {
       humanMinUsdcAmount: string,
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
-      signature?: Buffer,
+      registerUserSignature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -256,7 +256,7 @@ export class Exchange {
         zeroExResponseObject.to,
         zeroExResponseObject.allowanceTarget,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ).send(options);
     }
 
@@ -271,7 +271,7 @@ export class Exchange {
         zeroExResponseObject.to,
         zeroExResponseObject.allowanceTarget,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ),
       options,
     );
@@ -282,12 +282,12 @@ export class Exchange {
       starkKey,
       positionId,
       zeroExResponseObject,
-      signature = Buffer.from('', 'utf8'),
+      registerUserSignature = Buffer.from('', 'utf8'),
     }: {
       starkKey: string,
       positionId: BigNumberable,
       zeroExResponseObject: ZeroExSwapResponse,
-      signature?: Buffer,
+      registerUserSignature?: Buffer,
     },
     options?: SendOptions,
   ): Promise<TxResult> {
@@ -304,7 +304,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ).send({ ...options, value: zeroExResponseObject.value });
     }
 
@@ -316,7 +316,7 @@ export class Exchange {
         bignumberableToUint256(positionId),
         zeroExResponseObject.to,
         zeroExResponseObject.data,
-        signature,
+        registerUserSignature,
       ),
       { ...options, value: zeroExResponseObject.value },
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface ParsedLog extends Log {
 export interface ZeroExSwapResponse {
   guaranteedPrice: string,
   to: string,
-  data: string,
+  data: Buffer,
   value: string,
   buyAmount: string,
   sellAmount: string,


### PR DESCRIPTION
Biconomy has been proven to work with proxyDeposit. Therefore, I am adding Biconomy to all other gasful (not a word) methods from the depositContract. Also, when a signature is present as != '' we try to register the user on the contract deposit call. This is critical for the FE