### PR TITLE
Add affiliateAddress to 0x quote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-eth",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/clients/zeroEx.ts
+++ b/src/clients/zeroEx.ts
@@ -27,6 +27,7 @@ export async function getZeroExSwapQuote({
     url: generateQueryPath(
       zeroExUrlMap[networkId],
       {
+        affiliateAddress: '0xB03fc94a3c49B3126A4E6523D10b65d82C44729C',
         sellAmount,
         sellToken,
         buyToken: buyTokenAddress,


### PR DESCRIPTION
The 0x quote endpoint has the optional(?) parameter of `affiliateAddress`.  It is the specified ETH address for which to attribute the trade for tracking and analytics purposes.